### PR TITLE
Add patch for AMD ZEN to fix microphone issue

### DIFF
--- a/Resources/Controllers.plist
+++ b/Resources/Controllers.plist
@@ -471,6 +471,16 @@
 				<key>Replace</key>
 				<data>DCBmNSIQdAQxwP/I</data>
 			</dict>
+			<dict>
+				<key>Count</key>
+				<integer>1</integer>
+				<key>Find</key>
+				<data>9sIBdQ0=</data>
+				<key>Name</key>
+				<string>AppleHDAController</string>
+				<key>Replace</key>
+				<data>9sIBkJA=</data>
+			</dict>
 		</array>
 		<key>Vendor</key>
 		<string>AMDZEN</string>
@@ -512,6 +522,16 @@
 				<key>Replace</key>
 				<data>DCBmNSIQdAQxwP/I</data>
 			</dict>
+			<dict>
+				<key>Count</key>
+				<integer>1</integer>
+				<key>Find</key>
+				<data>9sIBdQ0=</data>
+				<key>Name</key>
+				<string>AppleHDAController</string>
+				<key>Replace</key>
+				<data>9sIBkJA=</data>
+			</dict>
 		</array>
 		<key>Vendor</key>
 		<string>AMDZEN</string>
@@ -552,6 +572,16 @@
 				<string>AppleHDAController</string>
 				<key>Replace</key>
 				<data>DCBmNSIQdAQxwP/I</data>
+			</dict>
+			<dict>
+				<key>Count</key>
+				<integer>1</integer>
+				<key>Find</key>
+				<data>9sIBdQ0=</data>
+				<key>Name</key>
+				<string>AppleHDAController</string>
+				<key>Replace</key>
+				<data>9sIBkJA=</data>
 			</dict>
 		</array>
 		<key>Vendor</key>


### PR DESCRIPTION
In the function AppleHDAController::getAudioStreamLinkPositionInDMABuffer(IOHDAStream*, uint64_t*), it expects bit 0 of register 0x70 to be cleared before reading DMA position. However, for AMD, it somehow is not cleared, hence DMA position is incorrect. For now the workround is to skip that bit check.

This patch has been veried to work up to macOS Sonoma.